### PR TITLE
Config.RealtorJobName and better system for adding the realtor job.

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -29,7 +29,7 @@ RegisterNUICallback("hideUI", function()
 end)
 
 local function setRealtor(jobInfo)
-	if jobInfo.name == "realtor" then
+	if jobInfo.name == Config.RealtorJobName then
 		SendNUIMessage({
 			action = "setRealtorGrade",
 			data = jobInfo.grade.level

--- a/server/server.lua
+++ b/server/server.lua
@@ -5,14 +5,12 @@ RegisterNetEvent('QBCore:Server:UpdateObject', function()
 	QBCore = exports['qb-core']:GetCoreObject() 
 end)
 
-QBCore.Functions.AddJob(Config.Job.label:lower(), Config.Job)
-
 RegisterNetEvent("bl-realtor:server:updateProperty", function(type, property_id, data)
     -- Job check
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.Job.label then return false end
+    if not PlayerData.job.name == Config.RealtorJobName then return false end
 
     data.realtorSrc = src
     -- Update property
@@ -24,7 +22,7 @@ RegisterNetEvent("bl-realtor:server:registerProperty", function(data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.Job.label then return false end
+    if not PlayerData.job.name == Config.RealtorJobName then return false end
 
     data.realtorSrc = src
     -- Register property
@@ -36,7 +34,7 @@ RegisterNetEvent("bl-realtor:server:addTenantToApartment", function(data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.Job.label then return false end
+    if not PlayerData.job.name == Config.RealtorJobName then return false end
 
     data.realtorSrc = src
     -- Add tenant
@@ -47,7 +45,7 @@ lib.callback.register("bl-realtor:server:getNames", function (source, data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.Job.label then return false end
+    if not PlayerData.job.name == Config.RealtorJobName then return false end
     
     local names = {}
     for i = 1, #data do

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,28 +1,36 @@
 Config = Config or {}
 
-Config.Job = {
-    label = 'Realtor',
-    defaultDuty = true,
-    offDutyPay = false,
-    grades = {
-        ['0'] = {
-            name = 'Trainee',
-            payment = 200
-        },
-        ['1'] = {
-            name = 'Realtor',
-            payment = 350
-        },
-        ['2'] = {
-            name = 'Manager',
-            pay = 500
-        },
-        ['3'] = {
-            name = 'Owner',
-            pay = 750
-        }
-    }
-}
+-- Add this to qbcore/shared/jobs.lua
+
+--[[
+
+	['realtor'] = {
+		label = 'Realtor',
+		defaultDuty = true,
+		offDutyPay = false,
+		grades = {
+            ['0'] = {
+                name = 'Trainee',
+                payment = 200
+            },
+            ['1'] = {
+                name = 'Realtor',
+                payment = 350
+            },
+			['2'] = {
+                name = 'Manager',
+                payment = 500
+            },
+			['3'] = {
+                name = 'Owner',
+				isboss = true,
+                payment = 750
+            },
+        }, 
+
+--]]
+
+Config.RealtorJobName = "realtor" -- Set your Real Estate here
 
 --Commisions is handled in ps-housing config.
 


### PR DESCRIPTION
Added Config.RealtorJobName in client/server instead of "realtor". Also added the Config.RealtorJobName in the config file with a default of realtor job.

Removed the QBCore.Functions.AddJob and added a guide on how to add the job to qbcore manually (for better overview)
